### PR TITLE
Replace request by fetch and fix actions to allow parallel action processing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,6 @@ module.exports = {
     "react/sort-comp": "off",
     "arrow-parens": ["error", "always"],
     "no-restricted-syntax": ["off", "ForInStatement"],
-    "comma-dangle": ["warn", "only-multiline"],
     "react/prop-types": ["error", {
       ignore: ["actions"]
     }],

--- a/package-lock.json
+++ b/package-lock.json
@@ -6850,7 +6850,8 @@
     "psl": {
       "version": "1.1.27",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.27.tgz",
-      "integrity": "sha512-J8tJX5tAeEp9tQTI2w2aMZ6V1INuU4JmNaNPRuHAqjjVq3ZJ+jV3+tcT3ncgTnBxvwJy740IB/WZrxFus2VdMA=="
+      "integrity": "sha512-J8tJX5tAeEp9tQTI2w2aMZ6V1INuU4JmNaNPRuHAqjjVq3ZJ+jV3+tcT3ncgTnBxvwJy740IB/WZrxFus2VdMA==",
+      "dev": true
     },
     "pstree.remy": {
       "version": "1.1.0",
@@ -6864,7 +6865,8 @@
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
     },
     "qs": {
       "version": "6.5.2",
@@ -7277,6 +7279,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "dev": true,
       "requires": {
         "lodash": "^4.13.1"
       }
@@ -7285,6 +7288,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
       "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+      "dev": true,
       "requires": {
         "request-promise-core": "1.1.1",
         "stealthy-require": "^1.1.0",
@@ -8103,7 +8107,8 @@
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
     },
     "stream-combiner": {
       "version": "0.0.4",
@@ -8742,6 +8747,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.2.tgz",
       "integrity": "sha512-vahm+X8lSV/KjXziec8x5Vp0OTC9mq8EVCOApIsRAooeuMPSO8aT7PFACYkaL0yZ/3hVqw+8DzhCJwl8H2Ad6w==",
+      "dev": true,
       "requires": {
         "psl": "^1.1.24",
         "punycode": "^1.4.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2357,6 +2357,11 @@
         "is-symbol": "^1.0.1"
       }
     },
+    "escape-regex-string": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/escape-regex-string/-/escape-regex-string-1.0.6.tgz",
+      "integrity": "sha512-AcaPwAOKpF52ETT4uu4vmpqQphuQGjIEhdDwG/gAJYah8ixJlrSBFjhtLMT7frc9y3RWgOnLov9E0MsRBdeRbw=="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "react-test-renderer": "^16.4.1",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
-    "request-promise-native": "^1.0.5",
     "uuid": "^3.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "aphrodite": "^2.2.1",
     "babel-runtime": "^6.26.0",
     "classnames": "^2.2.6",
+    "escape-regex-string": "^1.0.6",
     "lodash": "^4.17.10",
     "prop-types": "^15.6.1",
     "react-is": "^16.4.1",

--- a/src/Action.js
+++ b/src/Action.js
@@ -12,22 +12,16 @@ class Action extends Smart {
 
   static type = '__UNDEFINED__';
 
-  static export(customOptions, ...args) {
-    return (options) => new this({ ...options, ...customOptions }, ...args);
+  static export(options, ...args) {
+    return (context) => new this({ ...options, ...context }, ...args);
   }
 
-  initialize(_options) {
-    const { success, error, ...options } = _.isPlainObject(_options) ? _options : {};
-    this._successCallback = success;
-    this._errorCallback = error;
-    this.extend({ options });
-  }
-
-  defaults(options = {}) {
-    return ({
-      status: 'pending',
-      ...options,
-    });
+  defaults({ success, error, ...options }) {
+    return {
+      _successCallback: success,
+      _errorCallback: error,
+      options,
+    };
   }
 
   parsePayload = (payload) => payload;

--- a/src/Action.js
+++ b/src/Action.js
@@ -15,7 +15,7 @@ class Action extends Smart {
   defaults(options = {}) {
     return ({
       status: 'pending',
-      ...options
+      ...options,
     });
   }
 
@@ -35,7 +35,7 @@ class Action extends Smart {
 
   _defaultOptions = (options) => this.defaultOptions({
     delegate: false,
-    ...options
+    ...options,
   });
 
   _export = (payload, data) => this.export({

--- a/src/Action.js
+++ b/src/Action.js
@@ -13,7 +13,7 @@ class Action extends Smart {
   static type = '__UNDEFINED__';
 
   static export(customOptions, ...args) {
-    return (options) => new this(Object.assign({}, options, customOptions), ...args);
+    return (options) => new this({ ...options, ...customOptions }, ...args);
   }
 
   initialize(_options) {

--- a/src/Action.js
+++ b/src/Action.js
@@ -12,8 +12,15 @@ class Action extends Smart {
 
   static type = '__UNDEFINED__';
 
-  static export(...options) {
-    return () => new this(...options);
+  static export(customOptions, ...args) {
+    return (options) => new this(Object.assign({}, options, customOptions), ...args);
+  }
+
+  initialize(_options) {
+    const { success, error, ...options } = _.isPlainObject(_options) ? _options : {};
+    this._successCallback = success;
+    this._errorCallback = error;
+    this.extend({ options });
   }
 
   defaults(options = {}) {
@@ -42,8 +49,8 @@ class Action extends Smart {
     ...options,
   });
 
-  _export = (payload, data) => this.export({
-    payload: this._parsePayload(payload, data) || false,
+  _export = (payload) => this.export({
+    payload: this._parsePayload(payload) || false,
     type: this.constructor.type,
     timestamp: this.timestamp,
     options: this.options,
@@ -55,21 +62,17 @@ class Action extends Smart {
     return resolve.call(this, this.parsePayload, payload);
   }
 
-  _call(data, _options) {
-    const { success, error, ...options } = _.isPlainObject(_options) ? _options : {};
+  _call(...data) {
     this.id = uuid();
     this.timestamp = Date.now();
-    this._successCallback = success;
-    this._errorCallback = error;
     return (dispatch, getState) => {
-      this.extend({ options });
       this._setGetState(getState);
-      this._dispatchPending(dispatch, data);
+      this._dispatchPending(dispatch, ...data);
       new Promise(async () => { /* eslint-disable-line no-new */
         this._bindActionsCreators(dispatch, getState);
-        const payload = await this._processPayload(data, options);
-        await dispatch(this._export(payload, data));
-        await this._afterDispatch(payload, data);
+        const payload = await this._processPayload(...data);
+        await dispatch(this._export(payload));
+        await this._afterDispatch(payload, ...data);
       });
       return this.id;
     };
@@ -83,76 +86,70 @@ class Action extends Smart {
     };
   }
 
-  _dispatchPending(dispatch, data) {
+  _dispatchPending(dispatch, ...data) {
     this.setStatus('pending');
-    const pendingPayload = resolve.call(this, this.pendingPayload, data);
-    dispatch(this._export(pendingPayload, data));
+    const pendingPayload = resolve.call(this, this.pendingPayload, ...data);
+    dispatch(this._export(pendingPayload));
   }
 
   _bindActionsCreators(dispatch, getState) {
     const actionCreators = this.constructor.actionCreators;
     _.each(actionCreators, (action, key) => {
       if (typeof action === 'function') {
-        this[key] = (data, options = {}) => new Promise((success, error) => {
-          const actionInstance = action();
-          actionInstance._call(
-            data,
-            { success, error, delegate: true, ...options },
-          )(dispatch, getState);
+        this[key] = (...data) => new Promise((success, error) => {
+          const actionInstance = action({ success, error, delegate: true });
+          actionInstance._call(...data)(dispatch, getState);
         });
       }
     });
   }
 
-  async _processPayload(data, options) {
+  async _processPayload(...data) {
     if (typeof this.call === 'function') {
       try {
-        const call = await this.call(data, options);
+        const call = await this.call(...data);
         const payload = await resolve(call);
-        return await this._processSuccess(payload, data);
+        return await this._processSuccess(payload, ...data);
       } catch (exception) {
         if (exception instanceof Error) log.error(exception);
         const error = (exception instanceof Error) ? {} : exception;
-        return this._processError(error, data);
+        return this._processError(error, ...data);
       }
     } else if (this.call !== undefined) {
       return this.call;
     }
-    return this._processSuccess(data, null);
+    return this._processSuccess(...data);
   }
 
-  async _afterDispatch(payload, data) {
+  async _afterDispatch(payload, ...data) {
     if (this.status === 'success') {
       await resolve.call(this, this._successCallback, payload);
-      resolve.call(this, this.afterDispatch, payload, data);
+      resolve.call(this, this.afterDispatch, payload, ...data);
     } else {
       resolve.call(this, this._errorCallback, payload);
     }
   }
 
-  async _processSuccess(payload, data) {
+  async _processSuccess(payload, ...data) {
     this.setStatus('success');
-    const success = resolve.call(this, this.payload, payload, data);
-    await resolve.call(this, this._successCallback, payload, data);
+    const success = resolve.call(this, this.payload, payload, ...data);
+    await resolve.call(this, this._successCallback, payload, ...data);
     return success;
   }
 
-  async _processError(payload, data) {
+  async _processError(payload, ...data) {
     this.setStatus('error');
-    const error = resolve.call(this, this.error, payload, data);
-    await resolve.call(this, this._errorCallback, error, data);
+    const error = resolve.call(this, this.error, payload, ...data);
+    await resolve.call(this, this._errorCallback, error, ...data);
     return error;
   }
 
   static bind(context) {
-    const action = this.export(context);
-    return (data, options = {}) => new Promise((success, error) => {
+    return (...data) => new Promise((success, error) => {
       const { dispatch, getState } = Runtime('store');
+      const action = this.export({ success, error, delegate: true, ...context });
       const actionInstance = action();
-      actionInstance._call(
-        data,
-        { success, error, delegate: true, ...options },
-      )(dispatch, getState);
+      actionInstance._call(...data)(dispatch, getState);
     });
   }
 

--- a/src/Container.js
+++ b/src/Container.js
@@ -93,7 +93,7 @@ export default (Pure) => {
         listen: PropTypes.func.isRequired,
         location: PropTypes.object.isRequired,
         push: PropTypes.func.isRequired,
-      })
+      }),
     };
 
     static getDerivedStateFromProps(props, state) {

--- a/src/Container.js
+++ b/src/Container.js
@@ -53,11 +53,19 @@ export default (Pure) => {
     });
   }
 
+  function createActionsInstances(actions) {
+    return _.mapValues(actions, (action) => {
+      const actionInstance = action();
+      return (...args) => actionInstance._call(...args);
+    });
+  }
+
   function wrapDispatchToProps() {
     const dispatchToProps = Pure.dispatchToProps || {};
     return (dispatch, ownProps) => {
       const actionCreators = resolve(dispatchToProps, { dispatch, ownProps });
-      const boundActions = bindActionCreators(actionCreators, dispatch);
+      const actionsInstances = createActionsInstances(actionCreators);
+      const boundActions = bindActionCreators(actionsInstances, dispatch);
       const actions = hookActions(boundActions);
       return { dispatch, ...actions };
     };
@@ -77,6 +85,8 @@ export default (Pure) => {
   const options = getConnectOptions();
 
   class Container extends React.Component {
+
+    state = {};
 
     static displayName = `Container(${displayName})`;
 
@@ -100,8 +110,6 @@ export default (Pure) => {
       prevProps = props;
       return state;
     }
-
-    state = {};
 
     componentWillUnmount() {
       actionStack.clear();

--- a/src/Container.js
+++ b/src/Container.js
@@ -47,15 +47,15 @@ export default (Pure) => {
   }
 
   function hookActions(actions) {
-    return _.mapValues(actions, (action, key) => (data, options) => {
-      const id = action(data, { delegate: false, ...options });
+    return _.mapValues(actions, (action, key) => (...data) => {
+      const id = action(...data);
       actionStack.push({ id, key });
     });
   }
 
-  function createActionsInstances(actions) {
+  function createActionsInstances(actions, options) {
     return _.mapValues(actions, (action) => {
-      const actionInstance = action();
+      const actionInstance = action(options);
       return (...args) => actionInstance._call(...args);
     });
   }
@@ -64,7 +64,7 @@ export default (Pure) => {
     const dispatchToProps = Pure.dispatchToProps || {};
     return (dispatch, ownProps) => {
       const actionCreators = resolve(dispatchToProps, { dispatch, ownProps });
-      const actionsInstances = createActionsInstances(actionCreators);
+      const actionsInstances = createActionsInstances(actionCreators, { delegate: false });
       const boundActions = bindActionCreators(actionsInstances, dispatch);
       const actions = hookActions(boundActions);
       return { dispatch, ...actions };

--- a/src/Core.js
+++ b/src/Core.js
@@ -23,7 +23,7 @@ class Core extends Smart {
       reducer: options.reducer || ((state) => state),
       container: options.container || (() => <div>It works!</div>),
       context: options.context || React.createContext({}),
-      store: new Store({ reducer: options.reducer })
+      store: new Store({ reducer: options.reducer }),
     });
   }
 

--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -60,7 +60,8 @@ class Reducer extends Smart {
     return (state, action) => {
       let next = state;
       const { type } = action;
-      _.each(map, (pointer, regex) => {
+      _.each(map, (pointer, match) => {
+        const regex = new RegExp(`(^[^.]?|[.])${match}`, 'g');
         if (type && type.match(regex)) {
           const resolvedState = resolve.call(this, pointer, state, action);
           next = this.reduce(next, resolvedState, action);

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -16,7 +16,7 @@ class Resource extends Smart {
       method: resolver('method') || log.error('Resource method is undefined'),
       baseUri: resolver('baseUri') || '/',
       headers: resolver('headers') || {},
-      cors: resolver('cors') || false,
+      allowCors: resolver('allowCors') || false,
       responseType: resolver('responseType') || 'json',
       collection: resolver('collection') || false,
       requestParser: resolver('requestParser', false) || ((payload) => payload),

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -16,6 +16,8 @@ class Resource extends Smart {
       method: resolver('method') || log.error('Resource method is undefined'),
       baseUri: resolver('baseUri') || '/',
       headers: resolver('headers') || {},
+      cors: resolver('cors') || false,
+      responseType: resolver('responseType') || 'json',
       collection: resolver('collection') || false,
       requestParser: resolver('requestParser', false) || ((payload) => payload),
       responseParser: resolver('responseParser', false) || ((response) => response),
@@ -23,7 +25,7 @@ class Resource extends Smart {
       requestTransform: resolver('requestTransform') === false ? false : _.snakeCase,
       responseTransform: resolver('responseTransform') === false ? false : _.camelCase,
       options: resolver('options') || {},
-      ...this.context() || {}
+      ...this.context() || {},
     };
   }
 

--- a/src/Router.js
+++ b/src/Router.js
@@ -8,28 +8,28 @@ const historyHook = ({ location, action }) => ({
   type: 'ROUTER.EVENT',
   payload: {
     location,
-    action
-  }
+    action,
+  },
 });
 
 class Router extends React.Component {
 
   static dispatchToProps = ({ ownProps }) => ({
-    historyHook: ownProps.historyHook || historyHook
+    historyHook: ownProps.historyHook || historyHook,
   });
 
   static propTypes = {
     history: PropTypes.object,
-    historyHook: PropTypes.func.isRequired
+    historyHook: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
-    history: History
+    history: History,
   };
 
   static propsToContext = ({ ownProps }) => ({
     location: ownProps.history.location,
-    history: ownProps.history
+    history: ownProps.history,
   });
 
   constructor(props, state) {

--- a/src/Store.js
+++ b/src/Store.js
@@ -19,7 +19,7 @@ class Store extends Smart {
     if (__DEV__ && global.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) {
       return global.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
         latency: 1000,
-        maxAge: 25
+        maxAge: 25,
       });
     }
     return compose;
@@ -63,7 +63,7 @@ class Store extends Smart {
       `%c${header} ${time} ${status}`,
       'color: #2A2F3A; font-weight: bold;',
       '\n | Action: ', action,
-      '\n | State:  ', state
+      '\n | State:  ', state,
     ];
   }
 

--- a/src/Store.js
+++ b/src/Store.js
@@ -1,4 +1,5 @@
 import { createStore, applyMiddleware, compose } from 'redux';
+import _ from 'lodash';
 import Thunk from 'redux-thunk';
 import Smart from './Smart';
 import log from './helpers/log';
@@ -8,6 +9,9 @@ class Store extends Smart {
   initialize({ reducer }) {
     const reduxStore = this._createStore(reducer);
     this.extend(reduxStore);
+    if (__DEV__) {
+      this.extend({ pendingActions: [] });
+    }
   }
 
   _createStore(reducer = this.reducer) {
@@ -41,10 +45,19 @@ class Store extends Smart {
 
   _logger({ getState }) {
     return (next) => (action) => {
-      const state = getState();
-      const timeStarted = Date.now();
+      let state;
+      let duration = null;
+      if (action.status === 'pending') {
+        state = getState();
+        this.pendingActions.push({ id: action.id, startTime: performance.now() });
+      }
       const payload = next(action);
-      const duration = (Date.now() - timeStarted);
+      if (action.status !== 'pending') {
+        state = getState();
+        const [initialAction] = _.remove(this.pendingActions, (pendingAction) =>
+          pendingAction.id === action.id);
+        duration = performance.now() - initialAction.startTime;
+      }
       const output = this._formatLog(state, action, duration);
       if (action.status === 'error') {
         log.warning(...output);
@@ -58,9 +71,12 @@ class Store extends Smart {
   _formatLog(state, action, duration) {
     const header = `dispatched ${String(action.type)}`;
     const status = (action.status ? `[${action.status}]` : '[no-status]');
-    const time = `(in ${duration.toFixed(2)} ms)`;
+    let time = ' ';
+    if (duration) {
+      time = ` (completed in ${duration >= 1000 ? `${(duration / 1000).toFixed(2)} s` : `${duration.toFixed(0)} ms`}) `;
+    }
     return [
-      `%c${header} ${time} ${status}`,
+      `%c${header}${time}${status}`,
       'color: #2A2F3A; font-weight: bold;',
       '\n | Action: ', action,
       '\n | State:  ', state,

--- a/src/helpers/aphrodite.js
+++ b/src/helpers/aphrodite.js
@@ -13,7 +13,7 @@ const { StyleSheet, css } = Aphrodite.extend([{
       }
     });
     return _.isEmpty(nestedTags) ? null : _.flattenDeep(nestedTags);
-  }
+  },
 }]);
 
 export { StyleSheet, css };

--- a/src/internal/ResourceCall.js
+++ b/src/internal/ResourceCall.js
@@ -40,14 +40,22 @@ class ResourceCall extends Smart {
     }
   }
 
-  _entityParser(entity) {
+  _promiseAllObject(obj) {
+    const keys = Object.keys(obj);
+    return Promise.all(Object.values(obj)).then((resolvedValues) => {
+      const resolvedObject = {};
+      keys.forEach((key, index) => {
+        resolvedObject[key] = resolvedValues[index];
+      });
+      return resolvedObject;
+    });
+  }
+
+  async _entityParser(entity) {
     const { collection, entityParser } = this.context;
     if (collection === true) {
-      const parsedEntities = entity;
-      for (const key in entity) {
-        parsedEntities[key] = entityParser(entity[key]);
-      }
-      return Promise.all(Object.values(parsedEntities));
+      const parsedEntities = entity.map((value) => entityParser(value, this.context));
+      return Promise.all(parsedEntities);
     }
     return entityParser(entity, this.context);
   }

--- a/src/internal/ResourceCall.js
+++ b/src/internal/ResourceCall.js
@@ -110,7 +110,8 @@ class ResourceCall extends Smart {
 
   _request(payload) {
     const { baseUri, path } = this.context;
-    const url = baseUri ? `${baseUri.replace(/\/$/, '')}${path}` : path;
+    let url = baseUri ? `${baseUri.replace(/\/$/, '')}${path}` : path;
+    url = url !== '/' ? url.replace(/\/$/, '') : url;
     const options = this._requestOptions(payload);
     return fetch(url, options);
   }

--- a/src/internal/ResourceCall.js
+++ b/src/internal/ResourceCall.js
@@ -22,33 +22,17 @@ class ResourceCall extends Smart {
     switch (responseType.toLowerCase()) {
       case 'json':
         return response.json();
-
       case 'text':
         return response.text();
-
       case 'formdata':
         return response.formData();
-
       case 'arraybuffer':
         return response.arrayBuffer();
-
       case 'blob':
         return response.blob();
-
       default:
         throw new Error('Unsupported response type');
     }
-  }
-
-  _promiseAllObject(obj) {
-    const keys = Object.keys(obj);
-    return Promise.all(Object.values(obj)).then((resolvedValues) => {
-      const resolvedObject = {};
-      keys.forEach((key, index) => {
-        resolvedObject[key] = resolvedValues[index];
-      });
-      return resolvedObject;
-    });
   }
 
   async _entityParser(entity) {
@@ -94,15 +78,13 @@ class ResourceCall extends Smart {
   }
 
   _requestOptions(payload) {
-    const { method, headers, cors } = this.context;
-
+    const { method, headers, allowCors } = this.context;
     const options = {
       method,
       credentials: 'same-origin',
-      cors: cors ? 'cors' : 'no-cors',
+      cors: allowCors ? 'cors' : 'no-cors',
       headers: new Headers(headers),
     };
-
     if (method !== 'GET' && method !== 'HEAD') {
       const parsedPayload = this._requestParser(payload);
       if (_.isPlainObject(parsedPayload)) {
@@ -112,14 +94,17 @@ class ResourceCall extends Smart {
         options.body = parsedPayload;
       }
     }
-
     return options;
+  }
+
+  _requestUrl(baseUri, path) {
+    const url = baseUri ? `${baseUri.replace(/\/$/, '')}${path}` : path;
+    return url !== '/' ? url.replace(/\/$/, '') : url;
   }
 
   _request(payload) {
     const { baseUri, path } = this.context;
-    let url = baseUri ? `${baseUri.replace(/\/$/, '')}${path}` : path;
-    url = url !== '/' ? url.replace(/\/$/, '') : url;
+    const url = this._requestUrl(baseUri, path);
     const options = this._requestOptions(payload);
     return fetch(url, options);
   }

--- a/src/internal/ResourceCall.js
+++ b/src/internal/ResourceCall.js
@@ -110,7 +110,7 @@ class ResourceCall extends Smart {
 
   _request(payload) {
     const { baseUri, path } = this.context;
-    const url = baseUri ? `${baseUri}${path}` : path;
+    const url = baseUri ? `${baseUri.replace(/\/$/, '')}${path}` : path;
     const options = this._requestOptions(payload);
     return fetch(url, options);
   }

--- a/src/internal/ResourceCall.js
+++ b/src/internal/ResourceCall.js
@@ -40,14 +40,14 @@ class ResourceCall extends Smart {
     }
   }
 
-  async _entityParser(entity) {
+  _entityParser(entity) {
     const { collection, entityParser } = this.context;
     if (collection === true) {
       const parsedEntities = entity;
-      for (const key in entity) { /* eslint-disable no-await-in-loop */
-        parsedEntities[key] = await entityParser(entity[key]);
+      for (const key in entity) {
+        parsedEntities[key] = entityParser(entity[key]);
       }
-      return parsedEntities;
+      return Promise.all(Object.values(parsedEntities));
     }
     return entityParser(entity, this.context);
   }

--- a/src/internal/ResourceCall.js
+++ b/src/internal/ResourceCall.js
@@ -85,17 +85,9 @@ class ResourceCall extends Smart {
     return parsedPayload;
   }
 
-  _request(payload) {
-    const { baseUri, path } = this.context;
-    const url = baseUri ? `${baseUri}${path}` : path;
-    const options = this._requestOptions(payload);
-    return fetch(url, options);
-  }
-
-
   _requestOptions(payload) {
     const { method, headers, cors } = this.context;
-    const parsedPayload = this._requestParser(payload);
+
     const options = {
       method,
       credentials: 'same-origin',
@@ -104,6 +96,7 @@ class ResourceCall extends Smart {
     };
 
     if (method !== 'GET' && method !== 'HEAD') {
+      const parsedPayload = this._requestParser(payload);
       if (_.isPlainObject(parsedPayload)) {
         options.body = JSON.stringify(parsedPayload);
         options.headers.append('Content-Type', 'application/json');
@@ -113,6 +106,13 @@ class ResourceCall extends Smart {
     }
 
     return options;
+  }
+
+  _request(payload) {
+    const { baseUri, path } = this.context;
+    const url = baseUri ? `${baseUri}${path}` : path;
+    const options = this._requestOptions(payload);
+    return fetch(url, options);
   }
 
   call = async (payload) => {

--- a/tests/Action.test.js
+++ b/tests/Action.test.js
@@ -133,6 +133,9 @@ const testPayloadFormat = (obj) => {
   expect(obj).toHaveProperty('type');
   expect(obj).toHaveProperty('status');
   expect(obj).toHaveProperty('payload');
+  expect(obj).toHaveProperty('options');
+  expect(obj.options).toHaveProperty('delegate');
+  expect(obj.options).toBeInstanceOf(Boolean);
 };
 
 describe('the Action flow is correct', () => {

--- a/tests/Action.test.js
+++ b/tests/Action.test.js
@@ -84,7 +84,6 @@ describe('Action class', () => {
     action.call = () => {
       throw new Error('test');
     };
-    global.__DEV__ = false; // do no want log.error to spam test results
     const mockProcessError = jest.fn(async () => 'foo');
     action._processError = mockProcessError;
     const returnedValue = await action._processPayload('foo', 'bar');

--- a/tests/Action.test.js
+++ b/tests/Action.test.js
@@ -18,8 +18,9 @@ describe('Action class', () => {
     expect(action.status).toEqual('error');
   });
 
-  test('export correctly generates the dispatch', () => {
+  test('export correctly returns a wrapper to the action constructor', () => {
     expect(Action.export()).toBeInstanceOf(Function);
+    expect(Action.export()()).toBeInstanceOf(Action);
   });
 
   test('_dispatchPending works correctly', () => {
@@ -39,7 +40,7 @@ describe('Action class', () => {
   test('_processSuccess sets success status, call the onSuccess method and correcly returns', async () => {
     const onSuccess = jest.fn();
     const payload = { foo: 'bar' };
-    action.onSuccess = onSuccess;
+    action._successCallback = onSuccess;
     const returnedSuccess = await action._processSuccess(payload, 'data');
     expect(action.status).toEqual('success');
     expect(onSuccess).toHaveBeenCalledTimes(1);
@@ -50,7 +51,7 @@ describe('Action class', () => {
   test('_processError sets error status, call the onError method and correcly returns', async () => {
     const onError = jest.fn();
     const payload = { foo: 'bar' };
-    action.onError = onError;
+    action._errorCallback = onError;
     const returnedError = await action._processError(payload);
     expect(action.status).toEqual('error');
     expect(onError).toHaveBeenCalledTimes(1);
@@ -140,13 +141,13 @@ describe('the Action flow is correct', () => {
   let firstCall;
   let secondCall;
   beforeAll(async () => {
-    const action = MockAction.export();
+    const action = MockAction.export()();
     mockFunc = jest.fn();
     const tester = (data) => {
       mockFunc(data);
       testPayloadFormat(_.last(mockFunc.mock.calls)[0]);
     };
-    action()(tester);
+    action._call()(tester);
     await new Promise((res) => process.nextTick(res));
     [firstCall, secondCall] = _.flatten(mockFunc.mock.calls);
   });

--- a/tests/Resource.test.js
+++ b/tests/Resource.test.js
@@ -81,7 +81,7 @@ describe('Ressource Call Class', () => {
   test('_transform should parse correctly the payload object using the transform function given', () => {
     const obj = { fooProperty: 'some',
       barProp: {
-        otherProp: 'bar'
+        otherProp: 'bar',
       } };
     expect(resourceCall._transform(obj, _.snakeCase)).toEqual({ foo_property: 'some', bar_prop: { other_prop: 'bar' } });
   });

--- a/tests/Resource.test.js
+++ b/tests/Resource.test.js
@@ -74,7 +74,7 @@ describe('Ressource Call Class', () => {
   });
 
   test('_collection parser should return the correct attribute', async () => {
-    const collection = await resourceCall._collectionParser({ body: { collection: 'foo' } });
+    const collection = await resourceCall._collectionParser({ collection: 'foo' });
     expect(collection).toEqual('foo');
   });
 
@@ -112,7 +112,7 @@ describe('Ressource Call Class', () => {
     resourceCall.context = {
       responseParser: jest.fn((val) => val),
     };
-    const response = await resourceCall._responseParser({ body: { foo: 'bar' } });
+    const response = await resourceCall._responseParser({ foo: 'bar' });
     expect(response).toBeDefined();
     expect(response).toEqual({ foo: 'bar' });
     expect(resourceCall.context.responseParser).toHaveBeenCalledTimes(1);
@@ -122,8 +122,8 @@ describe('Ressource Call Class', () => {
     resourceCall.context = {
       collection: true,
     };
-    resourceCall._collectionParser = jest.fn((val) => val.body);
-    const response = await resourceCall._responseParser({ body: { foo: 'bar' } });
+    resourceCall._collectionParser = jest.fn((val) => val);
+    const response = await resourceCall._responseParser({ foo: 'bar' });
     expect(response).toBeDefined();
     expect(response).toEqual({ foo: 'bar' });
     expect(resourceCall._collectionParser).toHaveBeenCalledTimes(1);
@@ -134,7 +134,7 @@ describe('Ressource Call Class', () => {
       responseTransform: true,
     };
     resourceCall._transform = jest.fn((val) => val);
-    const response = await resourceCall._responseParser({ body: { foo: 'bar' } });
+    const response = await resourceCall._responseParser({ foo: 'bar' });
     expect(response).toBeDefined();
     expect(response).toEqual({ foo: 'bar' });
     expect(resourceCall._transform).toHaveBeenCalledTimes(1);
@@ -145,7 +145,7 @@ describe('Ressource Call Class', () => {
       entityParser: true,
     };
     resourceCall._entityParser = jest.fn((val) => val);
-    const response = await resourceCall._responseParser({ body: { foo: 'bar' } });
+    const response = await resourceCall._responseParser({ foo: 'bar' });
     expect(response).toBeDefined();
     expect(response).toEqual({ foo: 'bar' });
     expect(resourceCall._entityParser).toHaveBeenCalledTimes(1);

--- a/tests/__mocks__/MockAction.js
+++ b/tests/__mocks__/MockAction.js
@@ -3,7 +3,7 @@ import Action from '../../src/Action';
 class MockAction extends Action {
 
   static type = 'TEST';
-  call = (data, options) => data;
+  call = (data) => data;
   payload = (payload, data) => ({
     foo: 'bar',
   });

--- a/tests/__mocks__/MockComponent.js
+++ b/tests/__mocks__/MockComponent.js
@@ -10,7 +10,7 @@ class MockComponent extends React.Component {
   };
 
   static defaultProps = {
-    defaultProp: 'autoset'
+    defaultProp: 'autoset',
   };
 
   render() {

--- a/tests/__mocks__/MockReducers.js
+++ b/tests/__mocks__/MockReducers.js
@@ -9,7 +9,7 @@ class PlainObjectReducer extends Reducer {
   });
 
   state = this.match({
-    ADDTOOBJECT: this.addToObject
+    ADDTOOBJECT: this.addToObject,
   });
 
 }

--- a/tests/helpers/testUtils.js
+++ b/tests/helpers/testUtils.js
@@ -24,7 +24,7 @@ function diveTo(shallowWrapper, identifier, options = { context: {} }) {
   // it's necessary to manually pass down child context like this
   const context = _.extend(
     {}, instance && instance.getChildContext ? instance.getChildContext() : {},
-    options.context
+    options.context,
   );
 
   return diveTo(shallowWrapper.dive({ context }), identifier, { context });

--- a/tests/setupTests.js
+++ b/tests/setupTests.js
@@ -7,4 +7,5 @@ import Adapter from 'enzyme-adapter-react-16';
 
 configure({ adapter: new Adapter() });
 global.__DEV__ = false;
+global.console.error = () => {};
 


### PR DESCRIPTION
- Now it uses fetch for resources calls : you can now pass some more options like response type (default to json) or cors for external api calls.
- Updated actions to fix promise not resolving while starting actions in parallels
- Changed the way you call actions, you can now call them with many arguments instead of object data and options (you need to pass custom options in the export now)